### PR TITLE
feat: 알림 설정 변경 API 구현 #34

### DIFF
--- a/src/main/java/com/lived/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/lived/domain/notification/controller/NotificationController.java
@@ -1,15 +1,15 @@
 package com.lived.domain.notification.controller;
 
+import com.lived.domain.notification.dto.NotificationRequestDTO;
 import com.lived.domain.notification.dto.NotificationResponseDTO;
 import com.lived.domain.notification.enums.TargetType;
 import com.lived.domain.notification.service.NotificationService;
+import com.lived.domain.notification.service.NotificationSettingService;
 import com.lived.global.apiPayload.ApiResponse;
 import com.lived.global.apiPayload.code.GeneralSuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,8 +19,10 @@ import java.util.List;
 @RequiredArgsConstructor
 public class NotificationController {
     private final NotificationService notificationService;
+    private final NotificationSettingService notificationSettingService;
 
     @GetMapping("")
+    @Operation(summary = "알림 목록 조회 API", description = "특정 카테고리(ROUTINE, COMMUNITY 등)의 알림 목록을 조회합니다.")
     public ApiResponse<List<NotificationResponseDTO.NotificationDTO>> getNotifications(@RequestParam TargetType targetType) {
         // 사용자 ID 가져오기 추후 구현
         Long memberId = 1L;
@@ -31,12 +33,22 @@ public class NotificationController {
     }
 
     @GetMapping("/settings")
+    @Operation(summary = "알림 설정 조회 API", description = "사용자의 현재 알림 설정 ON/OFF 상태를 조회합니다.")
     public ApiResponse<NotificationResponseDTO.NotificationSettingDTO> getNotificationSetting() {
         // 사용자 ID 가져오기 추후 구현
         Long memberId = 1L;
 
-        NotificationResponseDTO.NotificationSettingDTO result = notificationService.getNotificationSetting(memberId);
+        NotificationResponseDTO.NotificationSettingDTO result = notificationSettingService.getNotificationSetting(memberId);
 
         return ApiResponse.onSuccess(GeneralSuccessCode.OK, result);
+    }
+
+    @PatchMapping("/settings")
+    @Operation(summary = "알림 설정 수정 API", description = "사용자의 알림 ON/OFF 상태를 변경합니다.")
+    public ApiResponse<NotificationResponseDTO.NotificationSettingDTO> updateNotificationSetting(@RequestBody NotificationRequestDTO.NotificationSettingDTO request) {
+        // 사용자 ID 가져오기 추후 구현
+        Long memberId = 1L;
+
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK, notificationSettingService.updateNotificationSetting(memberId, request));
     }
 }

--- a/src/main/java/com/lived/domain/notification/dto/NotificationRequestDTO.java
+++ b/src/main/java/com/lived/domain/notification/dto/NotificationRequestDTO.java
@@ -1,4 +1,17 @@
 package com.lived.domain.notification.dto;
 
+import lombok.Getter;
+
 public class NotificationRequestDTO {
+
+    @Getter
+    public static class NotificationSettingDTO {
+        private Boolean allEnabled;
+        private Boolean routineEnabled;
+        private Boolean communityEnabled;
+        private Boolean postLikeEnabled;
+        private Boolean commentEnabled;
+        private Boolean commentLikeEnabled;
+        private Boolean marketingEnabled;
+    }
 }

--- a/src/main/java/com/lived/domain/notification/entity/NotificationSetting.java
+++ b/src/main/java/com/lived/domain/notification/entity/NotificationSetting.java
@@ -1,6 +1,7 @@
 package com.lived.domain.notification.entity;
 
 import com.lived.domain.member.entity.Member;
+import com.lived.domain.notification.dto.NotificationRequestDTO;
 import com.lived.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -49,4 +50,30 @@ public class NotificationSetting extends BaseEntity {
     @Builder.Default
     @Column(name = "marketing_enabled", nullable = false)
     private Boolean marketingEnabled = false;
+
+    public void update(NotificationRequestDTO.NotificationSettingDTO request) {
+        // 전체 알림 설정(allEnabled)이 들어왔는지 확인
+        if (request.getAllEnabled() != null) {
+            this.allEnabled = request.getAllEnabled();
+
+            // 전체 설정이 바뀌면 하위 항목들도 모두 동일한 값으로 강제 변경
+            this.routineEnabled = request.getAllEnabled();
+            this.communityEnabled = request.getAllEnabled();
+            this.postLikeEnabled = request.getAllEnabled();
+            this.commentEnabled = request.getAllEnabled();
+            this.commentLikeEnabled = request.getAllEnabled();
+            this.marketingEnabled = request.getAllEnabled();
+
+            // 전체 설정을 건드렸을 때는 하위 개별 설정 로직을 타지 않고 바로 종료
+            return;
+        }
+
+        // 전체 설정이 들어오지 않은 경우에만 각자 개별적으로 업데이트
+        if (request.getRoutineEnabled() != null) this.routineEnabled = request.getRoutineEnabled();
+        if (request.getCommunityEnabled() != null) this.communityEnabled = request.getCommunityEnabled();
+        if (request.getPostLikeEnabled() != null) this.postLikeEnabled = request.getPostLikeEnabled();
+        if (request.getCommentEnabled() != null) this.commentEnabled = request.getCommentEnabled();
+        if (request.getCommentLikeEnabled() != null) this.commentLikeEnabled = request.getCommentLikeEnabled();
+        if (request.getMarketingEnabled() != null) this.marketingEnabled = request.getMarketingEnabled();
+    }
 }

--- a/src/main/java/com/lived/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/lived/domain/notification/service/NotificationService.java
@@ -20,7 +20,6 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class NotificationService {
     private final NotificationRepository notificationRepository;
-    private final NotificationSettingRepository notificationSettingRepository;
 
     public List<NotificationResponseDTO.NotificationDTO> getNotificationByCategory(Long memberId, TargetType targetType) {
         List<Notification> notifications = notificationRepository.findAllByMemberIdAndTargetOrderByCreatedAtDesc(memberId, targetType);
@@ -33,11 +32,5 @@ public class NotificationService {
         }
 
         return dtoNotificationList;
-    }
-
-    public NotificationResponseDTO.NotificationSettingDTO getNotificationSetting(Long memberId) {
-        NotificationSetting notificationSetting = notificationSettingRepository.findByMemberId(memberId);
-
-        return NotificationConverter.toNotificationSettingDTO(notificationSetting);
     }
 }

--- a/src/main/java/com/lived/domain/notification/service/NotificationSettingService.java
+++ b/src/main/java/com/lived/domain/notification/service/NotificationSettingService.java
@@ -1,0 +1,31 @@
+package com.lived.domain.notification.service;
+
+import com.lived.domain.notification.converter.NotificationConverter;
+import com.lived.domain.notification.dto.NotificationRequestDTO;
+import com.lived.domain.notification.dto.NotificationResponseDTO;
+import com.lived.domain.notification.entity.NotificationSetting;
+import com.lived.domain.notification.repository.NotificationSettingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotificationSettingService {
+    private final NotificationSettingRepository notificationSettingRepository;
+
+    public NotificationResponseDTO.NotificationSettingDTO getNotificationSetting(Long memberId) {
+        NotificationSetting notificationSetting = notificationSettingRepository.findByMemberId(memberId);
+
+        return NotificationConverter.toNotificationSettingDTO(notificationSetting);
+    }
+
+    public NotificationResponseDTO.NotificationSettingDTO updateNotificationSetting(Long memberId, NotificationRequestDTO.NotificationSettingDTO request) {
+        NotificationSetting notificationSetting = notificationSettingRepository.findByMemberId(memberId);
+
+        notificationSetting.update(request);
+
+        return NotificationConverter.toNotificationSettingDTO(notificationSetting);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #34

## 📝작업 내용

> 전체 알림 설정 on/off 선택 시, 다른 알림 설정도 동일하게 on/off 선택되도록 구현
> 다른 알림들은 독립적으로 작동하도록 구현
> 로컬환경 테스트까지 완료하였습니다

### 스크린샷 (선택)
<img width="858" height="709" alt="스크린샷 2026-01-19 오후 4 28 49" src="https://github.com/user-attachments/assets/fe042ff5-fa00-48da-bb64-5276f5441ef1" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
