### PR TITLE
refactor: 소셜 로그인 경로 수정 및 Swagger 설정 보완 #49

### DIFF
--- a/src/main/java/com/lived/global/auth/AuthController.java
+++ b/src/main/java/com/lived/global/auth/AuthController.java
@@ -2,6 +2,8 @@ package com.lived.global.auth;
 
 import com.lived.domain.member.service.MemberService;
 import com.lived.global.jwt.JwtTokenProvider;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -15,8 +17,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Arrays;
 
+@Tag(name = "인증/로그인", description = "소셜 로그인 및 토큰 관리 API")
 @RestController
-@RequestMapping("/api/v1/auth")
+@RequestMapping("/api/auth")
 @RequiredArgsConstructor
 public class AuthController {
 
@@ -24,6 +27,7 @@ public class AuthController {
     private final JwtTokenProvider jwtTokenProvider;
 
     @PostMapping("/reissue")
+    @Operation(summary = "액세스 토큰 재발급", description = "쿠키에 저장된 refreshToken을 검증하여, 만료된 액세스 토큰을 새로 발급하고 쿠키를 갱신합니다.")
     public ResponseEntity<?> reissue(HttpServletRequest request, HttpServletResponse response) {
         // 쿠키에서 refreshToken 꺼내기
         String refreshToken = getCookieValue(request, "refreshToken");

--- a/src/main/java/com/lived/global/config/SecurityConfig.java
+++ b/src/main/java/com/lived/global/config/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
 
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
-                                "/api/v1/auth/**",
+                                "/api/auth/**",
                                 "/login/**",
                                 "/oauth2/**",
                                 "/v3/api-docs/**",
@@ -65,6 +65,9 @@ public class SecurityConfig {
 
                 // OAuth2 로그인 설정 추가
                 .oauth2Login(oauth2 -> oauth2
+                        .authorizationEndpoint(authorization -> authorization
+                                .baseUri("/api/auth/login") //  /api/auth/login/{provider}로 매핑
+                        )
                         .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
                         .successHandler(oAuth2SuccessHandler)
                 );

--- a/src/main/java/com/lived/global/config/SwaggerConfig.java
+++ b/src/main/java/com/lived/global/config/SwaggerConfig.java
@@ -1,21 +1,32 @@
 package com.lived.global.config;
 
-
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.Paths;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.parameters.Parameter;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.List;
+
 @Configuration
 public class SwaggerConfig {
 
     @Bean
     public OpenAPI swagger() {
-        Info info = new Info().title("Project").description("Project Swagger").version("0.0.1");
+        Info info = new Info()
+                .title("살아보니 API 명세서")
+                .description("자취생 루틴 관리 서비스 '살아보니' 백엔드 API")
+                .version("1.0.0");
 
         // JWT 토큰 헤더 방식
         String securityScheme = "JWT TOKEN";
@@ -28,10 +39,27 @@ public class SwaggerConfig {
                         .scheme("Bearer")
                         .bearerFormat("JWT"));
 
+        // 소셜 로그인 API 수동 등록
+        Paths paths = new Paths();
+        paths.addPathItem("/api/auth/login/{provider}", new PathItem()
+                .get(new Operation()
+                        .tags(List.of("인증/로그인"))
+                        .summary("소셜 로그인 및 가입 확인")
+                        .description("사용자를 소셜 로그인 페이지로 리다이렉트합니다. {provider}에 google 또는 kakao를 입력하세요.")
+                        .addParametersItem(new Parameter()
+                                .name("provider")
+                                .in("path")
+                                .required(true)
+                                .description("소셜 서비스 제공자 (google, kakao)")
+                                .schema(new StringSchema()._enum(List.of("google", "kakao"))))
+                        .responses(new ApiResponses()
+                                .addApiResponse("302", new ApiResponse().description("소셜 로그인 페이지로 리다이렉트 성공")))));
+
         return new OpenAPI()
                 .info(info)
                 .addServersItem(new Server().url("/"))
                 .addSecurityItem(securityRequirement)
-                .components(components);
+                .components(components)
+                .paths(paths);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #49

## 📝작업 내용

> 소셜 로그인 엔드포인트 수정 (/api/auth/login/{provider})
> AuthController 경로에서 v1 제거
> Swagger 수동 경로 등록

### 스크린샷 (선택)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
