### PR TITLE
fix: Firebase 설정 파일 누락으로 인한 500 에러 및 배포 환경 개선

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,7 @@ jobs:
             sudo docker stop lived-app || true
             sudo docker rm lived-app || true
             sudo docker run -d --name lived-app -p 8080:8080 \
+              -v /home/ubuntu/serviceAccountKey.json:/app/resources/serviceAccountKey.json \
               -e SPRING_PROFILES_ACTIVE=prod \
               -e RDS_URL='${{ secrets.RDS_URL }}' \
               -e RDS_USERNAME='${{ secrets.RDS_USERNAME }}' \


### PR DESCRIPTION
## 📝작업 내용

> Docker 실행 시 -v 옵션을 사용하여 EC2 호스트의 키 파일을 컨테이너 내부(/app/resources/)로 마운트하도록 설정 변경.
