### PR TITLE
feat: 루틴나무 모아보기 구현 완료 (페이징 적용) #103

### DIFF
--- a/src/main/java/com/lived/domain/routine/controller/RoutineStatisticsController.java
+++ b/src/main/java/com/lived/domain/routine/controller/RoutineStatisticsController.java
@@ -1,9 +1,6 @@
 package com.lived.domain.routine.controller;
 
-import com.lived.domain.routine.dto.FruitPopupResponseDTO;
-import com.lived.domain.routine.dto.MonthlyFruitSummaryDTO;
-import com.lived.domain.routine.dto.MonthlyTrackerViewResponseDTO;
-import com.lived.domain.routine.dto.RoutineTreeResponseDTO;
+import com.lived.domain.routine.dto.*;
 import com.lived.domain.routine.service.RoutineStatisticsService;
 import com.lived.global.apiPayload.ApiResponse;
 import com.lived.global.apiPayload.code.GeneralSuccessCode;
@@ -73,5 +70,19 @@ public class RoutineStatisticsController {
         return ApiResponse.onSuccess(GeneralSuccessCode.OK, result);
     }
 
-
+    @Operation(
+            summary = "루틴 나무 모아보기",
+            description = "월별 나무 현황을 최신순으로 페이징하여 조회합니다. (page는 0부터 시작, size는 한 번에 불러올 월의 개수)"
+    )
+    @GetMapping("/trees")
+    public ApiResponse<RoutineTreeListResponseDTO> getRoutineTreeList(
+            @AuthMember Long memberId,
+            @Parameter(description = "페이지 번호 (0부터 시작)", example = "0")
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @Parameter(description = "한 번에 불러올 개수", example = "5")
+            @RequestParam(name = "size", defaultValue = "5") int size
+    ) {
+        RoutineTreeListResponseDTO result = routineStatisticsService.getRoutineTreeListPaging(memberId, page, size);
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK, result);
+    }
 }

--- a/src/main/java/com/lived/domain/routine/converter/RoutineStatisticsConverter.java
+++ b/src/main/java/com/lived/domain/routine/converter/RoutineStatisticsConverter.java
@@ -1,0 +1,63 @@
+package com.lived.domain.routine.converter;
+
+import com.lived.domain.routine.dto.RoutineTreeListResponseDTO;
+import com.lived.domain.routine.entity.RoutineFruit;
+import com.lived.domain.routine.entity.enums.FruitType;
+import org.springframework.stereotype.Component;
+
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+public class RoutineStatisticsConverter {
+
+    public RoutineTreeListResponseDTO toRoutineTreePagingResponseDTO(
+            List<RoutineFruit> fetchedFruits,
+            int size,
+            int page,
+            boolean hasNext
+    ) {
+        Map<YearMonth, List<RoutineFruit>> fruitsMap = fetchedFruits.stream()
+                .collect(Collectors.groupingBy(f -> YearMonth.from(f.getMonth())));
+
+        List<RoutineTreeListResponseDTO.MonthlyTreeInfoDTO> treeInfos = new ArrayList<>();
+
+        YearMonth currentBase = YearMonth.now();
+
+        YearMonth startMonthOfPage = currentBase.minusMonths((long) page * size);
+
+        for (int i = 0; i < size; i++) {
+            YearMonth targetYm = startMonthOfPage.minusMonths(i);
+
+            List<RoutineFruit> monthlyFruits = fruitsMap.getOrDefault(targetYm, new ArrayList<>());
+            int gold = (int) monthlyFruits.stream().filter(f -> f.getFruitType() == FruitType.GOLD).count();
+            int normal = (int) monthlyFruits.stream().filter(f -> f.getFruitType() == FruitType.NORMAL).count();
+            int growing = (int) monthlyFruits.stream().filter(f -> f.getFruitType() == FruitType.GROWING).count();
+
+            List<RoutineTreeListResponseDTO.FruitPreviewDTO> fruitPreviews = monthlyFruits.stream()
+                    .map(f -> RoutineTreeListResponseDTO.FruitPreviewDTO.builder()
+                            .memberRoutineId(f.getMemberRoutine().getId().intValue()) // Long -> int 형변환
+                            .fruitType(f.getFruitType())
+                            .build())
+                    .toList();
+
+            treeInfos.add(RoutineTreeListResponseDTO.MonthlyTreeInfoDTO.builder()
+                    .year(targetYm.getYear())
+                    .month(targetYm.getMonthValue())
+                    .fruits(fruitPreviews)
+                    .goldCount(gold)
+                    .normalCount(normal)
+                    .growingCount(growing)
+                    .build());
+        }
+
+        return RoutineTreeListResponseDTO.builder()
+                .hasNext(hasNext)
+                .currentPage(page)
+                .trees(treeInfos)
+                .build();
+    }
+}

--- a/src/main/java/com/lived/domain/routine/dto/RoutineTreeListResponseDTO.java
+++ b/src/main/java/com/lived/domain/routine/dto/RoutineTreeListResponseDTO.java
@@ -1,0 +1,44 @@
+package com.lived.domain.routine.dto;
+
+import com.lived.domain.routine.entity.enums.FruitType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RoutineTreeListResponseDTO {
+
+    private boolean hasNext;
+    private int currentPage;
+    private List<MonthlyTreeInfoDTO> trees;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MonthlyTreeInfoDTO {
+        private int year;
+        private int month;
+
+        private List<FruitPreviewDTO> fruits;
+
+        private int goldCount;
+        private int normalCount;
+        private int growingCount;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class FruitPreviewDTO {
+        private int memberRoutineId;
+        private FruitType fruitType;
+    }
+}

--- a/src/main/java/com/lived/domain/routine/repository/RoutineFruitRepository.java
+++ b/src/main/java/com/lived/domain/routine/repository/RoutineFruitRepository.java
@@ -1,5 +1,6 @@
 package com.lived.domain.routine.repository;
 
+import com.lived.domain.routine.entity.Routine;
 import com.lived.domain.routine.entity.RoutineFruit;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -13,4 +14,7 @@ public interface RoutineFruitRepository extends JpaRepository<RoutineFruit, Long
 
     // memberRoutine 엔티티 안의 member 엔티티의 id 필드로 조회
     List<RoutineFruit> findAllByMemberRoutineMemberIdAndMonth(Long memberId, LocalDate month);
+
+    // StartDate와 EndDate 사이의 Month를 가진 데이터를 전부 조회
+    List<RoutineFruit> findAllByMemberRoutineMemberIdAndMonthBetween(Long memberId, LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/com/lived/domain/routine/service/RoutineStatisticsService.java
+++ b/src/main/java/com/lived/domain/routine/service/RoutineStatisticsService.java
@@ -1,5 +1,6 @@
 package com.lived.domain.routine.service;
 
+import com.lived.domain.routine.converter.RoutineStatisticsConverter;
 import com.lived.domain.routine.dto.*;
 import com.lived.domain.routine.entity.RoutineFruit;
 import com.lived.domain.routine.entity.RoutineHistory;
@@ -16,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
@@ -31,6 +33,7 @@ public class RoutineStatisticsService {
     private final MemberRoutineRepository memberRoutineRepository;
     private final RoutineHistoryRepository routineHistoryRepository;
     private final RoutineFruitRepository routineFruitRepository;
+    private final RoutineStatisticsConverter routineStatisticsConverter;
 
     // 루틴 나무 전체 데이터 화면 반환
     public RoutineTreeResponseDTO getRoutineTree(Long memberId, int year, int month) {
@@ -187,6 +190,22 @@ public class RoutineStatisticsService {
         );
     }
 
+    // 루틴 나무 모아보기
+    public RoutineTreeListResponseDTO getRoutineTreeListPaging(Long memberId, int page, int size) {
 
+        YearMonth currentBase = YearMonth.now();
 
+        YearMonth latestYm = currentBase.minusMonths((long) page * size);
+
+        YearMonth oldestYm = latestYm.minusMonths(size - 1);
+
+        LocalDate startDate = oldestYm.atDay(1);
+        LocalDate endDate = latestYm.atEndOfMonth();
+
+        List<RoutineFruit> fetchedFruits = routineFruitRepository.findAllByMemberRoutineMemberIdAndMonthBetween(memberId, startDate, endDate);
+
+        boolean hasNext = oldestYm.getYear() >= 2025;
+
+        return routineStatisticsConverter.toRoutineTreePagingResponseDTO(fetchedFruits, size, page, hasNext);
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #103

## 📝작업 내용

> 루틴 나무 모아보기 API 구현했습니다.
> 페이징 처리 : 무한 스크롤 지원을 위해 최신 월부터 과거 순으로 page, size 기반 조회 로직 구현
> 빈 데이터 처리 : DB에 기록이 없는 달이라도 UI가 깨지지 않도록 빈 객체를 생성하여 반환하는 로직 추가

### 스크린샷 (선택)
<img width="1282" height="958" alt="스크린샷 2026-02-05 오후 7 52 54" src="https://github.com/user-attachments/assets/d2b3f80a-e98f-4b89-82d5-cd162c03b440" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
