### PR TITLE
feat: 멤버 엔티티 email 칼럼 추가 및 회원가입 로직 수정

### DIFF
--- a/src/main/java/com/lived/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/lived/domain/member/converter/MemberConverter.java
@@ -18,7 +18,8 @@ public class MemberConverter {
                 .socialId(request.getSocialId()) // 소셜id
                 .provider(request.getProvider()) // 소셜 제공자
                 .name(request.getName())         // 이름
-                .nickname(nickname) // 닉네임
+                .email(request.getEmail())       // 이메일
+                .nickname(nickname)              // 닉네임
                 .gender(request.getGender())     // 성별
                 .birth(request.getBirth())       // 생년월일
                 .livingPeriod(request.getLivingPeriod()) // 자취연차

--- a/src/main/java/com/lived/domain/member/dto/MemberRequestDTO.java
+++ b/src/main/java/com/lived/domain/member/dto/MemberRequestDTO.java
@@ -29,6 +29,9 @@ public class MemberRequestDTO {
         @NotBlank(message = "이름은 필수입니다.")
         private String name;
 
+        @Schema(description = "소셜 계정 이메일", example = "test@example.com")
+        private String email;
+
         // 회원가입 페이지에서 입력받는 정보
         @NotNull(message = "자취 연차 정보는 필수입니다.")
         private LivingPeriod livingPeriod;

--- a/src/main/java/com/lived/domain/member/entity/Member.java
+++ b/src/main/java/com/lived/domain/member/entity/Member.java
@@ -34,6 +34,9 @@ public class Member extends BaseEntity {
     @Column(name = "nickname", nullable = false, length = 64)
     private String nickname; // 서비스 내 활동명
 
+    @Column(name = "email", length = 128, nullable = false) // 이메일 필드 추가
+    private String email;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "gender", nullable = false)
     private Gender gender; // 사용자 성별

--- a/src/main/java/com/lived/global/oauth2/dto/OAuthAttributes.java
+++ b/src/main/java/com/lived/global/oauth2/dto/OAuthAttributes.java
@@ -11,15 +11,17 @@ public class OAuthAttributes {
     private String name;      // 소셜 프로필상의 이름
     private String socialId;  // 소셜 고유 식별자
     private String provider;  // GOOGLE, KAKAO
+    private String email; // 소셜 이메일
 
     @Builder
     public OAuthAttributes(Map<String, Object> attributes, String nameAttributeKey,
-                           String name, String socialId, String provider) {
+                           String name, String socialId, String provider, String email) {
         this.attributes = attributes;
         this.nameAttributeKey = nameAttributeKey;
         this.name = name;
         this.socialId = socialId;
         this.provider = provider;
+        this.email = email;
     }
 
     public static OAuthAttributes of(String registrationId, String userNameAttributeName, Map<String, Object> attributes) {
@@ -32,6 +34,7 @@ public class OAuthAttributes {
     private static OAuthAttributes ofGoogle(String userNameAttributeName, Map<String, Object> attributes) {
         return OAuthAttributes.builder()
                 .name((String) attributes.get("name"))
+                .email((String) attributes.get("email"))
                 .socialId((String) attributes.get("sub"))
                 .provider("GOOGLE")
                 .attributes(attributes)
@@ -45,6 +48,7 @@ public class OAuthAttributes {
 
         return OAuthAttributes.builder()
                 .name((String) profile.get("nickname"))
+                .email((String) kakaoAccount.get("email"))
                 .socialId(String.valueOf(attributes.get("id")))
                 .provider("KAKAO")
                 .attributes(attributes)

--- a/src/main/java/com/lived/global/oauth2/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/lived/global/oauth2/handler/OAuth2SuccessHandler.java
@@ -34,6 +34,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         boolean isNewMember = (boolean) oAuth2User.getAttributes().get("isNewMember");
         String socialId = (String) oAuth2User.getAttributes().get("socialId");
         String name = (String) oAuth2User.getAttributes().get("name");
+        String email = (String) oAuth2User.getAttributes().get("email");
         String provider = (String) oAuth2User.getAttributes().get("provider");
         Provider providerEnum = Provider.valueOf(provider.toUpperCase());
 
@@ -45,6 +46,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                     .queryParam("isNewMember", true)
                     .queryParam("socialId", socialId)
                     .queryParam("name", name)
+                    .queryParam("email", email)
                     .queryParam("provider", provider)
                     .build()
                     .encode(StandardCharsets.UTF_8)

--- a/src/main/java/com/lived/global/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/lived/global/oauth2/service/CustomOAuth2UserService.java
@@ -62,6 +62,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         Map<String, Object> memberData = new HashMap<>(attributes.getAttributes());
         memberData.put("isNewMember", isNewMember);
         memberData.put("name", attributes.getName());
+        memberData.put("email", attributes.getEmail());
         memberData.put("socialId", attributes.getSocialId());
         memberData.put("provider", attributes.getProvider());
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #57 

## 📝작업 내용

>멤버 엔티티에 email 칼럼 추가
> 소셜 로그인을 통한 회원가입시 email이 저장되도록 로직 수정

### 스크린샷 (선택)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
